### PR TITLE
Enable local authentication and in-memory storage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/useAuth";
 import Landing from "@/pages/landing";
+import Login from "@/pages/login";
 import Dashboard from "@/pages/dashboard";
 import CreatePermit from "@/pages/permits/create-permit";
 import PermitDetails from "@/pages/permits/permit-details";
@@ -18,7 +19,10 @@ function Router() {
   return (
     <Switch>
       {isLoading || !isAuthenticated ? (
-        <Route path="/" component={Landing} />
+        <>
+          <Route path="/" component={Landing} />
+          <Route path="/login" component={Login} />
+        </>
       ) : (
         <>
           <Route path="/" component={Dashboard} />

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -148,7 +148,7 @@ export default function Header() {
                     <Avatar className="w-8 h-8">
                       <AvatarImage src={user?.profileImageUrl || undefined} />
                       <AvatarFallback className="bg-primary text-primary-foreground text-sm font-medium">
-                        {getInitials(user?.firstName, user?.lastName, user?.email)}
+                        {getInitials(user?.firstName || undefined, user?.lastName || undefined, user?.email || undefined)}
                       </AvatarFallback>
                     </Avatar>
                     <span className="text-sm text-muted-foreground hidden sm:block">

--- a/client/src/lib/permits.ts
+++ b/client/src/lib/permits.ts
@@ -1,7 +1,7 @@
 export interface PermitType {
   title: string;
   subtitle: string;
-  icon: string;
+  icon: any;
   color: string;
   checklist: string[];
   ppe: string[];

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -89,7 +89,7 @@ export default function Dashboard() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = "/login";
       }, 500);
       return;
     }
@@ -302,16 +302,16 @@ export default function Dashboard() {
                               {config.title} - {permit.workDescription}
                             </h4>
                             <p className="text-sm text-muted-foreground" data-testid={`permit-location-${permit.id}`}>
-                              {permit.stationDuct} - {permit.areaSite} • {permit.permitNumber}
+                              {(permit.stationDuct || "")} - {(permit.areaSite || "")} • {permit.permitNumber}
                             </p>
                             <p className="text-xs text-muted-foreground">
-                              Creado el {new Date(permit.createdAt).toLocaleDateString('es-ES')}
+                              Creado el {new Date(permit.createdAt || Date.now()).toLocaleDateString('es-ES')}
                             </p>
                           </div>
                         </div>
                         <div className="flex items-center space-x-3">
                           <div data-testid={`permit-status-${permit.id}`}>
-                            {getStatusBadge(permit.status)}
+                            {getStatusBadge(permit.status || 'draft')}
                           </div>
                           <Button 
                             variant="ghost" 

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -13,8 +13,8 @@ export default function Landing() {
               <HardHat className="text-primary text-2xl mr-3" />
               <h1 className="text-xl font-bold text-foreground">YPFB Permisos de Trabajo</h1>
             </div>
-            <Button 
-              onClick={() => window.location.href = "/api/login"}
+            <Button
+              onClick={() => window.location.href = "/login"}
               className="bg-primary text-primary-foreground hover:bg-primary/90"
               data-testid="button-login"
             >
@@ -35,9 +35,9 @@ export default function Landing() {
               Gestiona de forma segura y eficiente todos los permisos de trabajo industrial. 
               Sistema integral para excavación, trabajos en caliente y en frío con análisis de riesgos completo.
             </p>
-            <Button 
+            <Button
               size="lg"
-              onClick={() => window.location.href = "/api/login"}
+              onClick={() => window.location.href = "/login"}
               className="bg-primary text-primary-foreground hover:bg-primary/90 px-8 py-4 text-lg"
               data-testid="button-get-started"
             >

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { apiRequest } from "@/lib/queryClient";
+import { useLocation } from "wouter";
+
+export default function Login() {
+  const [, navigate] = useLocation();
+  const [isRegister, setIsRegister] = useState(false);
+  const [form, setForm] = useState({
+    email: "",
+    password: "",
+    firstName: "",
+    lastName: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isRegister) {
+        await apiRequest("POST", "/api/register", form);
+      } else {
+        await apiRequest("POST", "/api/login", {
+          email: form.email,
+          password: form.password,
+        });
+      }
+      navigate("/");
+    } catch (err: any) {
+      alert(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="p-6">
+          <h2 className="text-2xl font-bold mb-4">
+            {isRegister ? "Registro" : "Inicio de Sesión"}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {isRegister && (
+              <>
+                <Input
+                  placeholder="Nombre"
+                  name="firstName"
+                  value={form.firstName}
+                  onChange={handleChange}
+                />
+                <Input
+                  placeholder="Apellido"
+                  name="lastName"
+                  value={form.lastName}
+                  onChange={handleChange}
+                />
+              </>
+            )}
+            <Input
+              placeholder="Email"
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+            />
+            <Input
+              placeholder="Contraseña"
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+              required
+            />
+            <Button type="submit" className="w-full">
+              {isRegister ? "Registrarse" : "Ingresar"}
+            </Button>
+          </form>
+          <Button
+            variant="link"
+            className="mt-4 w-full"
+            onClick={() => setIsRegister(!isRegister)}
+          >
+            {isRegister ? "¿Ya tienes cuenta? Inicia sesión" : "¿Necesitas una cuenta? Regístrate"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/permits/create-permit.tsx
+++ b/client/src/pages/permits/create-permit.tsx
@@ -28,7 +28,7 @@ export default function CreatePermit() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = "/login";
       }, 500);
       return;
     }
@@ -57,7 +57,7 @@ export default function CreatePermit() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/login";
         }, 500);
         return;
       }

--- a/client/src/pages/permits/permit-details.tsx
+++ b/client/src/pages/permits/permit-details.tsx
@@ -31,7 +31,7 @@ export default function PermitDetails() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = "/login";
       }, 500);
       return;
     }
@@ -66,7 +66,7 @@ export default function PermitDetails() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/login";
         }, 500);
         return;
       }
@@ -99,7 +99,7 @@ export default function PermitDetails() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/login";
         }, 500);
         return;
       }
@@ -214,7 +214,7 @@ export default function PermitDetails() {
                 </div>
               </div>
               <div className="flex items-center space-x-2">
-                {getStatusBadge(permit.status)}
+                {getStatusBadge(permit.status || 'draft')}
                 <span className="text-sm text-muted-foreground" data-testid="text-permit-number">
                   {permit.permitNumber}
                 </span>

--- a/client/src/pages/supervisor-dashboard.tsx
+++ b/client/src/pages/supervisor-dashboard.tsx
@@ -81,7 +81,7 @@ export default function SupervisorDashboard() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/login";
         }, 500);
         return;
       }
@@ -272,7 +272,7 @@ export default function SupervisorDashboard() {
                   <div className="space-y-4">
                     {permits.map((permit) => {
                       const config = getPermitTypeConfig(permit.type);
-                      const IconComponent = config.icon;
+                      const IconComponent: any = config.icon;
                       
                       return (
                         <div 
@@ -372,7 +372,7 @@ export default function SupervisorDashboard() {
                   <div className="space-y-4">
                     {activePermits.map((permit) => {
                       const config = getPermitTypeConfig(permit.type);
-                      const IconComponent = config.icon;
+                      const IconComponent: any = config.icon;
                       
                       return (
                         <div 

--- a/client/src/pages/validator-dashboard.tsx
+++ b/client/src/pages/validator-dashboard.tsx
@@ -38,7 +38,7 @@ export default function ValidatorDashboard() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = "/login";
       }, 500);
       return;
     }
@@ -73,7 +73,7 @@ export default function ValidatorDashboard() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/login";
         }, 500);
         return;
       }
@@ -185,7 +185,7 @@ export default function ValidatorDashboard() {
                   <div className="space-y-4">
                     {permits.map((permit) => {
                       const config = getPermitTypeConfig(permit.type);
-                      const IconComponent = config.icon;
+                  const IconComponent: any = config.icon;
                       
                       return (
                         <div 

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,13 +1,15 @@
-import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+// Conexión a base de datos deshabilitada para pruebas locales
+// import { drizzle } from "drizzle-orm/node-postgres";
+// import { Pool } from "pg";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is required");
-}
+// if (!process.env.DATABASE_URL) {
+//   throw new Error("DATABASE_URL environment variable is required");
+// }
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
-});
+// const pool = new Pool({
+//   connectionString: process.env.DATABASE_URL,
+//   ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+// });
 
-export const db = drizzle(pool);
+// export const db = drizzle(pool);
+export const db = {} as any;

--- a/server/localAuth.ts
+++ b/server/localAuth.ts
@@ -1,0 +1,93 @@
+import type { Express, RequestHandler } from "express";
+import session from "express-session";
+import passport from "passport";
+import { Strategy as LocalStrategy } from "passport-local";
+import { randomUUID } from "crypto";
+
+interface LocalUser {
+  id: string;
+  email: string;
+  password: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+const users: LocalUser[] = [];
+
+export async function setupAuth(app: Express) {
+  app.use(
+    session({
+      secret: process.env.SESSION_SECRET || "secret",
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  passport.use(
+    new LocalStrategy(
+      { usernameField: "email", passwordField: "password" },
+      (email, password, done) => {
+        const user = users.find(
+          (u) => u.email === email && u.password === password
+        );
+        if (!user) {
+          return done(null, false);
+        }
+        return done(null, user);
+      }
+    )
+  );
+
+  passport.serializeUser((user: any, done) => {
+    done(null, user.id);
+  });
+
+  passport.deserializeUser((id: string, done) => {
+    const user = users.find((u) => u.id === id);
+    done(null, user || false);
+  });
+
+  app.post("/api/register", (req, res) => {
+    const { email, password, firstName, lastName } = req.body;
+    if (users.some((u) => u.email === email)) {
+      return res.status(400).json({ message: "User already exists" });
+    }
+    const newUser: LocalUser = {
+      id: randomUUID(),
+      email,
+      password,
+      firstName,
+      lastName,
+    };
+    users.push(newUser);
+    req.login(newUser, (err) => {
+      if (err) {
+        return res.status(500).json({ message: "Registration failed" });
+      }
+      const { password: _pw, ...userWithoutPassword } = newUser;
+      res.json(userWithoutPassword);
+    });
+  });
+
+  app.post("/api/login", passport.authenticate("local"), (req, res) => {
+    const user = req.user as LocalUser;
+    const { password: _pw, ...userWithoutPassword } = user;
+    res.json(userWithoutPassword);
+  });
+
+  app.post("/api/logout", (req, res) => {
+    req.logout(() => {
+      res.json({ message: "Logged out" });
+    });
+  });
+}
+
+export const isAuthenticated: RequestHandler = (req, res, next) => {
+  if (req.isAuthenticated()) return next();
+  res.status(401).json({ message: "Unauthorized" });
+};
+
+export type { LocalUser };
+export { users };

--- a/server/localStorage.ts
+++ b/server/localStorage.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "crypto";
+import type {
+  Permit,
+  InsertPermit,
+  PermitHistory,
+  InsertPermitHistory,
+} from "@shared/schema";
+
+function sameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+class LocalStorage {
+  private permits: Permit[] = [];
+  private history: PermitHistory[] = [];
+
+  async createPermit(permitData: Omit<InsertPermit, "permitNumber">): Promise<Permit> {
+    const permit: Permit = {
+      ...permitData,
+      id: randomUUID(),
+      permitNumber: await this.generatePermitNumber(),
+      status: permitData.status || "draft",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Permit;
+    this.permits.push(permit);
+    await this.addPermitHistory({
+      permitId: permit.id,
+      action: "created",
+      performedBy: permit.createdBy!,
+      comments: "Permiso creado",
+    });
+    return permit;
+  }
+
+  async getPermit(id: string): Promise<Permit | undefined> {
+    return this.permits.find((p) => p.id === id);
+  }
+
+  async getPermits(filters: {
+    status?: string;
+    type?: string;
+    createdBy?: string;
+    validatedBy?: string;
+    approvedBy?: string;
+  } = {}): Promise<Permit[]> {
+    return this.permits.filter((p) => {
+      if (filters.status && p.status !== filters.status) return false;
+      if (filters.type && p.type !== filters.type) return false;
+      if (filters.createdBy && p.createdBy !== filters.createdBy) return false;
+      if (filters.validatedBy && p.validatedBy !== filters.validatedBy) return false;
+      if (filters.approvedBy && p.approvedBy !== filters.approvedBy) return false;
+      return true;
+    });
+  }
+
+  async updatePermit(id: string, updates: Partial<Permit>): Promise<Permit> {
+    const permit = await this.getPermit(id);
+    if (!permit) throw new Error("Permit not found");
+    Object.assign(permit, updates, { updatedAt: new Date() });
+    return permit;
+  }
+
+  async generatePermitNumber(): Promise<string> {
+    const year = new Date().getFullYear();
+    const next = this.permits.length + 1;
+    return `PT-${year}-${next.toString().padStart(3, "0")}`;
+  }
+
+  async addPermitHistory(
+    historyData: InsertPermitHistory
+  ): Promise<PermitHistory> {
+    const history: PermitHistory = {
+      ...historyData,
+      id: randomUUID(),
+      timestamp: new Date(),
+    } as PermitHistory;
+    this.history.push(history);
+    return history;
+  }
+
+  async getPermitHistory(permitId: string): Promise<PermitHistory[]> {
+    return this.history.filter((h) => h.permitId === permitId);
+  }
+
+  async getDashboardStats(_userId?: string) {
+    const today = new Date();
+    const activePermits = this.permits.filter((p) => p.status === "approved").length;
+    const pendingPermits = this.permits.filter(
+      (p) => p.status === "pending_validation" || p.status === "pending_approval"
+    ).length;
+    const approvedToday = this.permits.filter(
+      (p) => p.status === "approved" && p.updatedAt && sameDay(p.updatedAt, today)
+    ).length;
+    const expiringToday = this.permits.filter(
+      (p) => p.status === "approved" && p.workDate && sameDay(new Date(p.workDate), today)
+    ).length;
+    return { activePermits, pendingPermits, approvedToday, expiringToday };
+  }
+}
+
+export const storage = new LocalStorage();

--- a/server/pdf-generator.ts
+++ b/server/pdf-generator.ts
@@ -271,7 +271,7 @@ function generatePermitHTML(permit: Permit): string {
         </div>
     </div>
 
-    ${permit.ppeRequirements && permit.ppeRequirements.length > 0 ? `
+    ${permit.ppeRequirements && (permit.ppeRequirements as any[]).length > 0 ? `
     <div class="ppe-section">
         <h3>Equipo de Protección Personal Requerido</h3>
         <div class="ppe-grid">


### PR DESCRIPTION
## Summary
- add session-based local auth with register, login and logout endpoints
- replace database access with in-memory storage for permits
- introduce client login page and route to use local auth

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb38ade4832d8468a2a2a720c832